### PR TITLE
Ch1718/system outage page only updates on changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-utility",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-utility",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressDriver.ts
+++ b/src/drivers/express/ExpressDriver.ts
@@ -6,7 +6,7 @@ import { ExpressRouteDriver } from '../drivers';
 import * as cors from 'cors';
 import * as dotenv from 'dotenv';
 import { sentryRequestHandler, sentryErrorHandler } from '../../shared/SentryConnector';
-import { enforceAuthenticatedAccess, handleProcessTokenError, processToken } from '../../middleware';
+import { enforceAuthenticatedAccess } from '../../middleware';
 import * as cookieParser from 'cookie-parser';
 import { ExpressRouteAuthDriver } from '../drivers';
 import { setupWebsockets } from './ExpressWebsocketDriver';

--- a/src/drivers/express/ExpressWebsocketDriver.ts
+++ b/src/drivers/express/ExpressWebsocketDriver.ts
@@ -11,9 +11,10 @@ export function setupWebsockets(server: http.Server) {
      * client as string data, to be parsed on recieve
      */
     const socket = new WebSocket.Server({ server, path: '/outages' });
-    socket.on('connection', (ws: WebSocket) => {
+    socket.on('connection', async (ws: WebSocket) => {
         statusInteractor.outageReportChange((changes: OutageReport[]) => {
             ws.send(JSON.stringify(changes));
         });
+        ws.send(JSON.stringify(await statusInteractor.statusReport()));
     });
 }

--- a/src/status/statusInteractor.ts
+++ b/src/status/statusInteractor.ts
@@ -1,5 +1,9 @@
 import { StatusStore } from './statusStore';
 
+export async function statusReport() {
+    return await getDataStore().statusReport();
+}
+
 export function outageReportChange(callback: Function) {
     getDataStore().outageReportChanged(callback);
 }

--- a/src/status/statusStore.ts
+++ b/src/status/statusStore.ts
@@ -21,7 +21,10 @@ export class StatusStore {
         return this.instance;
     }
 
-    async statusReport() {
+    /**
+     * Returns the current unresolved statuses as an array of OutageReport[]
+     */
+    async statusReport(): Promise<OutageReport[]> {
         return await this.db.collection(COLLECTIONS.OUTAGE_REPORTS).find({ resolved: null }).toArray();
     }
 
@@ -33,7 +36,7 @@ export class StatusStore {
     outageReportChanged(callback: Function) {
         const stream = this.db.collection(COLLECTIONS.OUTAGE_REPORTS).watch();
         stream.on('change', async () => {
-            const changes: OutageReport[] = await this.db.collection(COLLECTIONS.OUTAGE_REPORTS).find({ resolved: null }).toArray();
+            const changes: OutageReport[] = await this.statusReport();
             callback(changes);
         });
     }

--- a/src/status/statusStore.ts
+++ b/src/status/statusStore.ts
@@ -21,6 +21,10 @@ export class StatusStore {
         return this.instance;
     }
 
+    async statusReport() {
+        return await this.db.collection(COLLECTIONS.OUTAGE_REPORTS).find({ resolved: null }).toArray();
+    }
+
     /**
      * Checks if the collection for outage reports has changed and returns back a updated list
      * of outages to the client via a callback method


### PR DESCRIPTION
Fixes a small bug with the websocket outage report functionality.  It adds returns what is currently down on connect.