### PR TITLE
make utility users route public

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-utility",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-utility",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "",
   "main": "app.js",
   "scripts": {

--- a/src/drivers/express/ExpressRouteAuthDriver.ts
+++ b/src/drivers/express/ExpressRouteAuthDriver.ts
@@ -2,7 +2,6 @@ import { Router } from 'express';
 import * as interactor from '../../maintenance/maintenanceInteractor';
 import { mapErrorToResponseData } from '../../shared/errors';
 import { UserToken } from '../../shared/user-token';
-import * as userInterractor from '../../users/userInteractor';
 
 export class ExpressRouteAuthDriver {
     public static buildRouter(): Router {
@@ -25,11 +24,6 @@ export class ExpressRouteAuthDriver {
             const code = mapErrorToResponseData(e);
             res.sendStatus(code);
         }
-      });
-
-    router.get('/utility-users', async(req, res) => {
-        const users = await userInterractor.getUsers();
-        res.send(users);
       });
     }
 }

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -6,6 +6,7 @@ import { ServerlessCache } from '../../cache';
 import * as maintenanceInteractor from '../../maintenance/maintenanceInteractor';
 import * as statusInteractor from '../../status/statusInteractor';
 import { OutageReport } from '../../shared/outageReport';
+import * as userInterractor from '../../users/userInteractor';
 
 /**
  * Serves as a factory for producing a router for the express app.rt
@@ -47,6 +48,11 @@ export default class ExpressRouteDriver {
     router.get('/maintenance', async(req, res) => {
       const mango = await maintenanceInteractor.getMaintenanceStatus();
       res.send(mango);
+    });
+
+    router.get('/utility-users', async(req, res) => {
+      const users = await userInterractor.getUsers();
+      res.send(users);
     });
 
     // VERSION CHECK


### PR DESCRIPTION
***Purpose***
This PR exposes the utility users route as a public endpoint

***Story***
This PR addresses Clubhouse story https://app.clubhouse.io/clarkcan/story/1914/401-when-learning-object-service-makes-request-to-utility-service