### PR TITLE
3774/fix-circleci-build-deploy-workflow-in-utility-service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,3 +82,5 @@ workflows:
           filters:
             branches:
               only: /master/
+          requires:
+            - build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clark-utility",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "clark-utility",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "ISC",
       "dependencies": {
         "body-parser": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clark-utility",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Adds a require statement to the build-deploy workflow so it doesn't try to deploy an image it hasn't built yet.  Completes story [3774/fix-circleci-build-deploy-workflow-in-utility-service](https://app.clubhouse.io/clarkcan/story/3774/fix-circleci-build-deploy-workflow-in-utility-service).